### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An extensible Model Context Protocol server that provides standardized access to social platform data and onchain data. Currently supports Farcaster (via Neynar API) with placeholder for Twitter integration. More platforms like Telegram including onchain data will be added soon.
 
+<a href="https://glama.ai/mcp/servers/lxmmleqcl8">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/lxmmleqcl8/badge" alt="Beyond Server MCP server" />
+</a>
+
 ## Features
 
 - **MCP Compliant**: Fully implements the Model Context Protocol specification
@@ -9,7 +13,6 @@ An extensible Model Context Protocol server that provides standardized access to
 - **Extensible**: Easy to add new platform providers
 - **Well-Formatted**: Optimized context formatting for LLM consumption
 - **Flexible Transport**: Supports both stdio and SSE/HTTP transports
-
 
 ## Supported Platforms
 
@@ -197,5 +200,3 @@ Contributions are welcome! Please feel free to submit a Pull Request.
    - Farcaster integration via Neynar API
    - MCP compliant server implementation
    - Support for both stdio and HTTP modes
-
-   


### PR DESCRIPTION
This PR adds a badge for the [Beyond MCP Server](https://glama.ai/mcp/servers/lxmmleqcl8) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/lxmmleqcl8">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/lxmmleqcl8/badge" alt="Beyond Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.